### PR TITLE
Create PublisherDetails component for publisher page - refs #60

### DIFF
--- a/__tests__/src/components/PublisherDetails.test.js
+++ b/__tests__/src/components/PublisherDetails.test.js
@@ -1,0 +1,36 @@
+import React from "react"
+import { shallow } from 'enzyme'
+import PublisherDetails from "../../../src/components/PublisherDetails"
+
+const data1 = {
+  "name": "Test",
+  "description": "This is description"
+}
+const data2 = {
+  "name": "Test"
+}
+
+describe("PublisherDetails component", () => {
+
+  it("should render div element with publisher name and description", () => {
+    const wrapper = shallow(
+      <PublisherDetails data={data1} />
+    )
+    expect(wrapper.find(".container")).toHaveLength(1)
+    expect(wrapper.find("h1")).toHaveLength(1)
+    expect(wrapper.find("h1").text()).toEqual("Test")
+    expect(wrapper.find("p")).toHaveLength(1)
+    expect(wrapper.find("p").text()).toEqual("This is description")
+  })
+
+  it("should render div element with publisher name and description", () => {
+    const wrapper = shallow(
+      <PublisherDetails data={data2} />
+    )
+    expect(wrapper.find(".container")).toHaveLength(1)
+    expect(wrapper.find("h1")).toHaveLength(1)
+    expect(wrapper.find("h1").text()).toEqual("Test")
+    expect(wrapper.find("p")).toHaveLength(0)
+  })
+
+})

--- a/__tests__/src/components/PublisherDetails.test.js
+++ b/__tests__/src/components/PublisherDetails.test.js
@@ -2,35 +2,25 @@ import React from "react"
 import { shallow } from 'enzyme'
 import PublisherDetails from "../../../src/components/PublisherDetails"
 
-const data1 = {
-  "name": "Test",
-  "description": "This is description"
-}
-const data2 = {
-  "name": "Test"
+const data = {
+  "name": "Publisher",
+  "title": "Title",
+  "joined": "2017-01-25"
 }
 
 describe("PublisherDetails component", () => {
 
-  it("should render div element with publisher name and description", () => {
+  it("should render publisher name, title and joined date", () => {
     const wrapper = shallow(
-      <PublisherDetails data={data1} />
+      <PublisherDetails data={data} />
     )
     expect(wrapper.find(".container")).toHaveLength(1)
     expect(wrapper.find("h1")).toHaveLength(1)
-    expect(wrapper.find("h1").text()).toEqual("Test")
+    expect(wrapper.find("h1").text()).toEqual("Publisher")
+    expect(wrapper.find("h2")).toHaveLength(1)
+    expect(wrapper.find("h2").text()).toEqual("Title")
     expect(wrapper.find("p")).toHaveLength(1)
-    expect(wrapper.find("p").text()).toEqual("This is description")
-  })
-
-  it("should render div element with publisher name and description", () => {
-    const wrapper = shallow(
-      <PublisherDetails data={data2} />
-    )
-    expect(wrapper.find(".container")).toHaveLength(1)
-    expect(wrapper.find("h1")).toHaveLength(1)
-    expect(wrapper.find("h1").text()).toEqual("Test")
-    expect(wrapper.find("p")).toHaveLength(0)
+    expect(wrapper.find("p").text()).toEqual("2017-01-25")
   })
 
 })

--- a/src/components/PublisherDetails.js
+++ b/src/components/PublisherDetails.js
@@ -8,17 +8,11 @@ class PublisherDetails extends React.Component {
 
 	render() {
 	  const {data} = this.props;
-    if(data.description) {
-      return (
-        <div className="container">
-          <h1>{ data.name }</h1>
-          <p>{ data.description }</p>
-        </div>
-      );
-    }
     return (
       <div className="container">
         <h1>{ data.name }</h1>
+        <h2>{ data.title }</h2>
+        <p>{ data.joined }</p>
       </div>
     )
   }

--- a/src/components/PublisherDetails.js
+++ b/src/components/PublisherDetails.js
@@ -1,0 +1,31 @@
+import React, {PropTypes} from 'react';
+
+class PublisherDetails extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+	render() {
+	  const {data} = this.props;
+    if(data.description) {
+      return (
+        <div className="container">
+          <h1>{ data.name }</h1>
+          <p>{ data.description }</p>
+        </div>
+      );
+    }
+    return (
+      <div className="container">
+        <h1>{ data.name }</h1>
+      </div>
+    )
+  }
+}
+
+PublisherDetails.propTypes = {
+  data: PropTypes.object.isRequired
+};
+
+export default PublisherDetails;


### PR DESCRIPTION
Created presentational component `PublisherDetails`:
* it requires `data` object with `name`, `title` and `joined` attributes to be passed as props
* it renders `div` element with:
  `<h1>` as publisher name
  `<h2>` as title
  `<p>` as joined date