### PR TITLE
[footer][s]: fixed overlapping footer bug - refs #81

### DIFF
--- a/src/components/footer/Footer.css
+++ b/src/components/footer/Footer.css
@@ -1,4 +1,12 @@
-footer{ background:#666666; padding: 25px 0; margin-top: 50px; }
+footer{
+  background:#666666;
+  padding: 25px 0;
+  margin-top: calc(100vh - 170px);
+  position: relative;
+  height: 120px;
+  clear:both;
+  padding-top:20px;
+ }
 footer p, footer a { color:#b5b5b5; font-size:14px; }
 footer a:hover { color:#fff; text-decoration: none;}
 footer .connect li a {

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -3,7 +3,7 @@ import "./Footer.css";
 
 function Footer() {
   return (
-    <footer className="navbar-fixed-bottom">
+    <footer>
       <div className="container">
         <div className="row">
           <div className="col-sm-6">


### PR DESCRIPTION
Now footer is shown always after the body. 
When body is shorter than viewport, footer is located in the bottom.