### PR TITLE
[s] fix travis build for failing test in datapackage.test.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "istanbul": "0.4.5",
     "jest": "^18.0.0",
     "json-loader": "^0.5.4",
+    "moment-timezone": "0.5.11",
     "nock": "^9.0.2",
     "npm-run-all": "3.1.2",
     "postcss-loader": "1.2.1",

--- a/tests/utils/datapackage.test.js
+++ b/tests/utils/datapackage.test.js
@@ -61,7 +61,7 @@ describe('fetch it all', () => {
     expect(data.length).toEqual(651)
     // console.log(JSON.stringify(data[0], null, 2))
     const expected = [
-      moment('2014-01-02').toISOString() // .format('YYYY-MM-DDTHH:mm:ss.SSS'), //tz('Europe/London').
+      moment('2014-01-02').toISOString()
       , 14.32
       , 14.59
       , '14.00'

--- a/tests/utils/datapackage.test.js
+++ b/tests/utils/datapackage.test.js
@@ -1,5 +1,6 @@
 import 'babel-polyfill'
 import jts from 'jsontableschema'
+import moment from 'moment-timezone'
 import nock from 'nock'
 
 import * as utils from '../../src/utils/datapackage'
@@ -60,13 +61,16 @@ describe('fetch it all', () => {
     expect(data.length).toEqual(651)
     // console.log(JSON.stringify(data[0], null, 2))
     const expected = [
-      new Date('2014-01-01T16:00:00.000Z'),
-      14.32,
-      14.59,
-      "14.00",
-      14.23
+      moment('2014-01-02').toISOString() // .format('YYYY-MM-DDTHH:mm:ss.SSS'), //tz('Europe/London').
+      , 14.32
+      , 14.59
+      , '14.00'
+      , 14.23
     ]
-    expect(data[0]).toEqual(expected)
-  });
-});
+    expect(data[0][0].toISOString()).toEqual(expected[0])
+    for (let count = 1; count < expected.length; count += 1) {
+      expect(data[0][count]).toEqual(expected[count])
+    }
+  })
+})
 


### PR DESCRIPTION
Travis build was failing for the timezone mismatch of the generated
date. Used moment-timezone to convert time to utc.

As the date field data from resources is not string, manually
assert that first by converting to string and then asserted others
in a for loop.

Ref - #117