### PR TITLE
[tidy-up] Separate views and resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     </h1>
   </div>
   <div class="react-me" data-type="data-views"></div>
-  <div class="react-me" data-type="resource-preview"></div>
+  <div class="react-me" data-type="resource-preview" data-resource="0"></div>
 </div>
   <script type="text/javascript">
     var bitstore = 'https://bits.staging.datapackaged.com/metadata'

--- a/src/containers/MultiViews.jsx
+++ b/src/containers/MultiViews.jsx
@@ -17,18 +17,21 @@ export class MultiViews extends React.Component {
 
   render() {
     let dp = this.state.dataPackage
-    let viewComponents = dp.views.map((view, idx) => {
-      // first let's fix up recline views ...
-      if (view.type == 'Graph') { // it's a recline view
-        view = viewutils.convertReclineToSimple(view)
-      }
-      let compiledView = viewutils.compileView(view, dp)
-      switch (view.specType) {
-        case 'simple': // convert to plotly then render
-          let spec = viewutils.simpleToPlotly(compiledView)
-          return <PlotlyChart data={spec.data} layout={spec.layout} idx={idx} />
-      }
-    })
+    let viewComponents
+    if(dp.views) {
+      viewComponents = dp.views.map((view, idx) => {
+        // first let's fix up recline views ...
+        if (view.type == 'Graph') { // it's a recline view
+          view = viewutils.convertReclineToSimple(view)
+        }
+        let compiledView = viewutils.compileView(view, dp)
+        switch (view.specType) {
+          case 'simple': // convert to plotly then render
+            let spec = viewutils.simpleToPlotly(compiledView)
+            return <PlotlyChart data={spec.data} layout={spec.layout} idx={idx} />
+        }
+      })
+    }
     return <div>{viewComponents}</div>
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,20 +4,24 @@ import '../node_modules/handsontable/dist/handsontable.full.min.css'
 import MultiViews from "./containers/MultiViews"; // eslint-disable-line
 import HandsOnTable from './components/dataPackageView/HandsOnTable'
 import * as dputils from './utils/datapackage'
+import * as viewutils from './utils/view'
 
 
 let DATA_PACKAGE = DATA_PACKAGE || {}
-let idx = 0
 
-// From the back-end we expect a template to have div elements with specific
-// class and data-type attributes:
-//
-// - To tell a front-end that a given div element is for React component, it
-// should have class=react-me.
-// - To tell a front-end which component to render in that div element, it
-// should provide data-type attribute - resource-preview for HandsOnTable and
-// data-views for the graphs.
-// - Also any properties can be passed from the back-end using data-* prefix.
+/**
+ * From the back-end we expect a template to have div elements with specific
+ * class, data-type and data-resource attributes:
+ *
+ * - To tell a front-end that a given div element is for React component, it
+ * should have class=react-me.
+ * - To tell a front-end which component to render in that div element, it
+ * should provide data-type attribute - resource-preview for HandsOnTable and
+ * data-views for the graphs.
+ * - To tell a front-end which resource to render, it should provide
+ * data-resource attirbute with index of resource or name.
+ * - Also any properties can be passed from the back-end using data-* prefix.
+ */
 
 dputils.fetchDataPackageAndData(DATA_PACKAGE_URL).then(dpObj => {
   DATA_PACKAGE = dpObj.descriptor
@@ -30,8 +34,9 @@ dputils.fetchDataPackageAndData(DATA_PACKAGE_URL).then(dpObj => {
 
 function renderComponentInElement(el) {
   if (el.dataset.type === 'resource-preview') {
-    ReactDOM.render(<HandsOnTable resource={DATA_PACKAGE.resources[idx]} idx={idx} />, el);
-    idx += 1
+    let idx = parseInt(el.dataset.resource)
+    let resource = viewutils.findResourceByNameOrIndex(DATA_PACKAGE, idx)
+    ReactDOM.render(<HandsOnTable resource={resource} idx={idx} />, el);
   } else if (el.dataset.type === 'data-views') {
     ReactDOM.render(<MultiViews dataPackage={DATA_PACKAGE} />, el);
   }

--- a/tests/containers/MultiViews.test.jsx
+++ b/tests/containers/MultiViews.test.jsx
@@ -62,10 +62,50 @@ const mockDescriptor = {
   ]
 }
 
-describe('Datapackage View Container', () => {
-  const wrapper = shallow(<MultiViews dataPackage={mockDescriptor} dataPackageUrl={'abc'} />)
+const mockDescriptorWithNoViews = {
+  name: 'demo-package'
+  , resources: [
+    {
+      name: 'demo-resource'
+      , path: 'data/demo-resource.csv'
+      , format: 'csv'
+      , mediatype: 'text/csv'
+      , schema: {
+        fields: [
+          {
+            name: 'Date'
+            , type: 'date'
+            , description: ''
+          }
+          , {
+            name: 'Open'
+            , type: 'number'
+            , description: ''
+          }
+          , {
+            name: 'High'
+            , type: 'number'
+            , description: ''
+          }
+        ]
+        , primaryKey: 'Date'
+      }
+      , _values: [
+        ['2014-01-01', 14.32, 14.59]
+        , ['2014-01-02', 14.06, 14.22]
+        , ['2014-01-05', 13.41, 14.00]
+      ]
+    }
+  ]
+}
 
-  it('should render data package panel component', () => {
+describe('MultiViews Container', () => {
+  it('should render PlotlyChart component', () => {
+    const wrapper = shallow(<MultiViews dataPackage={mockDescriptor} />)
+    expect(toJson(wrapper)).toMatchSnapshot()
+  })
+  it('should NOT render PlotlyChart if there is no views given', () => {
+    const wrapper = shallow(<MultiViews dataPackage={mockDescriptorWithNoViews} />)
     expect(toJson(wrapper)).toMatchSnapshot()
   })
 })

--- a/tests/containers/__snapshots__/MultiViews.test.jsx.snap
+++ b/tests/containers/__snapshots__/MultiViews.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`Datapackage View Container should render data package panel component 1`] = `
+exports[`MultiViews Container should NOT render PlotlyChart if there is no views given 1`] = `<div />`;
+
+exports[`MultiViews Container should render PlotlyChart component 1`] = `
 <div>
   <PlotlyChart
     data={


### PR DESCRIPTION
This is an additional PR for https://github.com/frictionlessdata/dpr-js/pull/127

* added `data-resource` attribute to html template that represents which resource to render
* refactored `index.jsx` to use `data-resource`
* refactored `MultiViews.jsx` to check if there is any views in a descriptor. If not it renders empty `div` element. Updated tests to check that case.