### PR TITLE
incrementally loading the page

### DIFF
--- a/mocks/fileMock.js
+++ b/mocks/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/mocks/styleMock.js
+++ b/mocks/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "license": "ISC",
   "jest": {
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/mocks/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/mocks/styleMock.js"
     },
     "transform": {
       ".*": "<rootDir>/node_modules/babel-jest"
@@ -36,9 +36,7 @@
     "verbose": true,
     "testRegex": "(/tests/.*).jsx?$",
     "globals": {
-      "DataPackageJsonUrl": "./fixtures/dp2/datapackage.json",
-      "remoteDpUrl": "https://raw.githubusercontent.com/frictionlessdata/dpr-js/gh-pages/fixtures/dp2/datapackage.json",
-      "remoteCsvUrl": "https://raw.githubusercontent.com/frictionlessdata/dpr-js/gh-pages/fixtures/dp1/data.csv"
+      "DATA_PACKAGE_URL": ""
     },
     "unmockedModulePathPatterns": [
       "react",

--- a/src/components/dataPackageView/HandsOnTable.jsx
+++ b/src/components/dataPackageView/HandsOnTable.jsx
@@ -1,25 +1,20 @@
 import React, { PropTypes } from 'react'
 import Handsontable from 'handsontable'
-import * as viewutils from '../../utils/view'
 
 class HandsOnTable extends React.Component {
 
   constructor(props) {
     super(props)
-    let compiledViewSpec = {
-      resources: [this.props.resource],
-      specType: 'handsontable'
-    }
-    let spec = viewutils.handsOnTableToHandsOnTable(compiledViewSpec)
-    this.state = {
-      spec: spec,
-      idx: this.props.idx
-    }
   }
 
   componentDidMount() {
     // Create and bind Handsontable when the container component triggers update
-    new Handsontable(document.getElementById(`hTable${this.state.idx}`), this.state.spec)
+    new Handsontable(document.getElementById(`hTable${this.props.idx}`), this.props.spec)
+  }
+
+  componentWillUpdate(nextProps) {
+    // Update Handsontable when new props are received
+    new Handsontable(document.getElementById(`hTable${nextProps.idx}`), nextProps.spec)
   }
 
   render() {

--- a/src/components/dataPackageView/PlotlyChart.jsx
+++ b/src/components/dataPackageView/PlotlyChart.jsx
@@ -8,6 +8,12 @@ class PlotlyChart extends React.Component {
   }
 
   componentDidMount() {
+    // draw a plot with initial data and layout
+    Plotly.newPlot(`plotly${this.props.idx}`, this.props.data, this.props.layout)
+  }
+
+  componentWillUpdate() {
+    // update the plot with new props
     Plotly.newPlot(`plotly${this.props.idx}`, this.props.data, this.props.layout)
   }
 

--- a/src/containers/MultiViews.jsx
+++ b/src/containers/MultiViews.jsx
@@ -27,8 +27,11 @@ export class MultiViews extends React.Component {
         let compiledView = viewutils.compileView(view, dp)
         switch (view.specType) {
           case 'simple': // convert to plotly then render
-            let spec = viewutils.simpleToPlotly(compiledView)
-            return <PlotlyChart data={spec.data} layout={spec.layout} idx={idx} />
+            let spec = {}
+            if(compiledView.resources[0]._values) {
+              spec = viewutils.simpleToPlotly(compiledView)
+            }
+            return <PlotlyChart data={spec.data} layout={spec.layout} idx={idx} key={idx} />
         }
       })
     }

--- a/src/utils/datapackage.js
+++ b/src/utils/datapackage.js
@@ -21,10 +21,6 @@ export async function fetchDataPackageAndData(dataPackageIdentifier) {
   return dp
 }
 
-export async function fetchDataPackageOnly(dataPackageIdentifier) {
-  return await new Datapackage(dataPackageIdentifier)
-}
-
 export async function fetchDataOnly(resource) {
   if (resource.descriptor.format === 'geojson') {
     const baseUrl = resource._basePath.replace('/datapackage.json', '')

--- a/src/utils/datapackage.js
+++ b/src/utils/datapackage.js
@@ -21,3 +21,21 @@ export async function fetchDataPackageAndData(dataPackageIdentifier) {
   return dp
 }
 
+export async function fetchDataPackageOnly(dataPackageIdentifier) {
+  return await new Datapackage(dataPackageIdentifier)
+}
+
+export async function fetchDataOnly(resource) {
+  if (resource.descriptor.format === 'geojson') {
+    const baseUrl = resource._basePath.replace('/datapackage.json', '')
+    const resourceUrl = `${baseUrl}/${resource._descriptor.path}`
+    const response = await fetch(resourceUrl)
+    return await response.json()
+  } else {
+    // we assume resource is tabular for now ...
+    const table = await resource.table
+    // rows are simple arrays -- we can convert to objects elsewhere as needed
+    const rowsAsObjects = false
+    return await table.read(rowsAsObjects)
+  }
+}

--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -73,7 +73,7 @@ export function handsOnTableToHandsOnTable(view) {
   const headers = view.resources[0].schema.fields.map(field => field.name)
   const data = getResourceCachedValues(view.resources[0])
   let height = null
-  if (data.length > 16) {
+  if (data && data.length > 16) {
     height = 432
   }
   return {
@@ -157,4 +157,3 @@ export function compileView(inView, dataPackage) {
   view.resources = compiledData
   return view
 }
-

--- a/tests/components/dataPackageView/handsontable.test.jsx
+++ b/tests/components/dataPackageView/handsontable.test.jsx
@@ -2,39 +2,22 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import HandsOnTable from '../../../src/components/dataPackageView/HandsOnTable'
 
-
-const mockResource = {
-  _values: [
-    [180, 18, "Tony"],
-    [192, 15, "Pavle"],
-    [160, 32, "Pero"],
-    [202, 23, "David"]
-  ],
-  name: "random",
-  schema: {
-    fields: [
-      {
-        name: "height",
-        type: "integer"
-      },
-      {
-        name: "age",
-        type: "integer"
-      },
-      {
-        name: "name",
-        type: "string"
-      }
-    ]
-  }
+const mockSpec = {
+  data: [
+    ['', 'Ford', 'Volvo', 'Toyota', 'Honda']
+    , ['2016', 10, 11, 12, 13]
+    , ['2017', 20, 11, 14, 13]
+    , ['2018', 30, 15, 12, 13]
+  ]
+  , colHeaders: true
 }
 
 describe('handsontable component', () => {
-  it('should receive a resource and convert into spec then store in local state', () => {
+  it('should receive correct props and render div with specific id', () => {
     const idx = 0
-    const wrapper = shallow(<HandsOnTable resource={mockResource} idx={idx} />)
-    expect(wrapper.state().idx).toEqual(0)
-    expect(wrapper.state().spec.data[0][2]).toEqual('Tony')
+    const wrapper = shallow(<HandsOnTable spec={mockSpec} idx={idx} />)
+    expect(wrapper.instance().props.idx).toEqual(0)
+    expect(wrapper.instance().props.spec.data[0][1]).toEqual('Ford')
     expect(wrapper.html()).toEqual(`<div id="hTable${idx}"></div>`)
   })
 })

--- a/tests/containers/MultiViews.test.jsx
+++ b/tests/containers/MultiViews.test.jsx
@@ -62,50 +62,21 @@ const mockDescriptor = {
   ]
 }
 
-const mockDescriptorWithNoViews = {
-  name: 'demo-package'
-  , resources: [
-    {
-      name: 'demo-resource'
-      , path: 'data/demo-resource.csv'
-      , format: 'csv'
-      , mediatype: 'text/csv'
-      , schema: {
-        fields: [
-          {
-            name: 'Date'
-            , type: 'date'
-            , description: ''
-          }
-          , {
-            name: 'Open'
-            , type: 'number'
-            , description: ''
-          }
-          , {
-            name: 'High'
-            , type: 'number'
-            , description: ''
-          }
-        ]
-        , primaryKey: 'Date'
-      }
-      , _values: [
-        ['2014-01-01', 14.32, 14.59]
-        , ['2014-01-02', 14.06, 14.22]
-        , ['2014-01-05', 13.41, 14.00]
-      ]
-    }
-  ]
-}
-
 describe('MultiViews Container', () => {
   it('should render PlotlyChart component', () => {
     const wrapper = shallow(<MultiViews dataPackage={mockDescriptor} />)
     expect(toJson(wrapper)).toMatchSnapshot()
   })
+
+  it('should render empty PlotlyChart if there is no data yet', () => {
+    delete mockDescriptor.resources[0]._values
+    const wrapper = shallow(<MultiViews dataPackage={mockDescriptor} />)
+    expect(toJson(wrapper)).toMatchSnapshot()
+  })
+
   it('should NOT render PlotlyChart if there is no views given', () => {
-    const wrapper = shallow(<MultiViews dataPackage={mockDescriptorWithNoViews} />)
+    delete mockDescriptor.views
+    const wrapper = shallow(<MultiViews dataPackage={mockDescriptor} />)
     expect(toJson(wrapper)).toMatchSnapshot()
   })
 })

--- a/tests/containers/__snapshots__/MultiViews.test.jsx.snap
+++ b/tests/containers/__snapshots__/MultiViews.test.jsx.snap
@@ -68,3 +68,12 @@ exports[`MultiViews Container should render PlotlyChart component 1`] = `
     } />
 </div>
 `;
+
+exports[`MultiViews Container should render empty PlotlyChart if there is no data yet 1`] = `
+<div>
+  <PlotlyChart
+    idx={0} />
+  <PlotlyChart
+    idx={1} />
+</div>
+`;

--- a/tests/index.test.jsx
+++ b/tests/index.test.jsx
@@ -1,0 +1,71 @@
+import 'babel-polyfill'
+import index from '../src/index'
+import ReactDOM from 'react-dom'
+import MultiViews from '../src/containers/MultiViews'
+import HandsOnTable from '../src/components/dataPackageView/HandsOnTable'
+import LeafletMap from '../src/components/dataPackageView/LeafletMap'
+import nock from 'nock'
+import * as viewutils from '../src/utils/view'
+
+
+const mock = nock('https://dp-vix-resource-and-view.com')
+              .persist()
+              .get('/datapackage.json')
+              .replyWithFile(200, './fixtures/dp-vix-resource-and-view/datapackage.json')
+              .get('/data/demo-resource.csv')
+              .replyWithFile(200, './fixtures/dp-vix-resource-and-view/data/demo-resource.csv')
+
+
+describe('how renderComponentInElement method works', () => {
+  ReactDOM.render = jest.fn()
+
+  it('should render MultiViews if element data-type = data-views', () => {
+    const divForDataView = {dataset: {type: "data-views"}}
+    index.renderComponentInElement(divForDataView)
+    expect(ReactDOM.render.mock.calls.length).toEqual(1)
+    expect(ReactDOM.render.mock.calls[0][0].type).toEqual(MultiViews)
+    expect(ReactDOM.render.mock.calls[0][0].props).toEqual({"dataPackage": {}})
+    expect(ReactDOM.render.mock.calls[0][1]).toEqual(divForDataView)
+  })
+
+  it('should render HandsOnTable if element data-type = resource-preview', () => {
+    viewutils.findResourceByNameOrIndex = jest.fn(() => {
+      return {format: 'csv'}
+    })
+    viewutils.handsOnTableToHandsOnTable = jest.fn(() => 'hTspec')
+    const divForResourcePreview = {dataset: {type: "resource-preview", resource: "0"}}
+    index.renderComponentInElement(divForResourcePreview)
+    expect(ReactDOM.render.mock.calls.length).toEqual(2)
+    expect(ReactDOM.render.mock.calls[1][0].type).toEqual(HandsOnTable)
+    expect(ReactDOM.render.mock.calls[1][0].props).toEqual({spec: 'hTspec', idx: 0})
+    expect(ReactDOM.render.mock.calls[1][1]).toEqual(divForResourcePreview)
+  })
+
+  it('should render LeafletMap if element data-type=resource-preview and format=geojson', () => {
+    viewutils.findResourceByNameOrIndex = jest.fn(() => {
+      return {format: 'geojson', _values: 'values'}
+    })
+    const divForResourcePreview = {dataset: {type: "resource-preview", resource: "0"}}
+    index.renderComponentInElement(divForResourcePreview)
+    expect(ReactDOM.render.mock.calls.length).toEqual(3)
+    expect(ReactDOM.render.mock.calls[2][0].type).toEqual(LeafletMap)
+    expect(ReactDOM.render.mock.calls[2][0].props).toEqual({featureCollection: 'values', idx: 0})
+    expect(ReactDOM.render.mock.calls[2][1]).toEqual(divForResourcePreview)
+  })
+})
+
+describe('how incrementally loading happens', () => {
+  it('should render first time after dp is fetched and second time when data is fetched', async () => {
+    index.renderComponentInElement = jest.fn()
+    const dpUrl = 'https://dp-vix-resource-and-view.com/datapackage.json'
+    const divForDataView = {dataset: {type: "view"}}
+    const divForResourcePreview = {dataset: {type: "resource"}}
+    await index.fetchDataPackageAndDataIncrementally(dpUrl, [divForDataView, divForResourcePreview])
+    // there are 1 view and 1 resource - each one renders twice
+    expect(index.renderComponentInElement.mock.calls.length).toEqual(4)
+    expect(index.renderComponentInElement.mock.calls[0][0]).toEqual(divForDataView)
+    expect(index.renderComponentInElement.mock.calls[1][0]).toEqual(divForResourcePreview)
+    expect(index.renderComponentInElement.mock.calls[2][0]).toEqual(divForDataView)
+    expect(index.renderComponentInElement.mock.calls[3][0]).toEqual(divForResourcePreview)
+  })
+})

--- a/tests/utils/datapackage.test.js
+++ b/tests/utils/datapackage.test.js
@@ -95,3 +95,12 @@ describe('fetch it all', () => {
   })
 })
 
+describe('fetch data only', () => {
+  it('takes a resource and fetches data', async () => {
+    const descriptor = 'https://dp-vix-resource-and-view.com/datapackage.json'
+    const dp = await new Datapackage(descriptor)
+    const resource = dp.resources[0]
+    const values = await utils.fetchDataOnly(resource)
+    expect(values[0][1]).toEqual(14.32)
+  })
+})

--- a/tests/utils/view.js
+++ b/tests/utils/view.js
@@ -40,6 +40,39 @@ const mockDescriptor = {
   , views: []
 }
 
+const mockDescriptorWithoutData =  {
+  name: 'demo-package'
+  , resources: [
+    {
+      name: 'demo-resource'
+      , path: 'data/demo-resource.csv'
+      , format: 'csv'
+      , mediatype: 'text/csv'
+      , schema: {
+        fields: [
+          {
+            name: 'Date'
+            , type: 'date'
+            , description: ''
+          }
+          , {
+            name: 'Open'
+            , type: 'number'
+            , description: ''
+          }
+          , {
+            name: 'High'
+            , type: 'number'
+            , description: ''
+          }
+        ]
+        , primaryKey: 'Date'
+      }
+    }
+  ]
+  , views: []
+}
+
 const mockViews = {
   recline: {
     id: 'Graph'
@@ -241,6 +274,33 @@ describe('Data Package View utils - HandsOnTable ', () => {
     // console.log(JSON.stringify(outSpec, null, 2));
     expect(outSpec).toEqual(expected)
   })
+
+  it('should generate handsontable without data', () => {
+    const view = {
+      name: 'table-resource1'
+      , resources: ['demo-resource']
+      , specType: 'handsontable'
+    }
+    const viewCompiled = utils.compileView(view, mockDescriptorWithoutData)
+    const outSpec = utils.handsOnTableToHandsOnTable(viewCompiled)
+    const expected = {
+      data: undefined
+      , colHeaders: [
+        'Date'
+        , 'Open'
+        , 'High'
+      ]
+      , readOnly: true
+      , width: 1136
+      , height: null
+      , colWidths: 47
+      , rowWidth: 27
+      , stretchH: 'all'
+      , columnSorting: true
+      , search: true
+    }
+    expect(outSpec).toEqual(expected)
+  })
 })
 
 
@@ -307,4 +367,3 @@ describe('Basic view utility functions', () => {
     expect(out.resources[0]._values.length).toEqual(3)
   })
 })
-


### PR DESCRIPTION
This pull request enables to load data views and resource previews incrementally. It initially loads when descriptor is fetched with empty graph and tables (with headers etc.). Then loading resources one by one happens. Once a resource is loaded it re-renders appropriate component.

PR also includes:
* `index.jsx` refactored to render components right after descriptor is fetched. Then it re-renders appropriate one each time a resource is loaded.
* HandsOnTable component returned to previous stage as a dumb component. Logic is moved to `index.jsx`. Also `componentWillUpdate` method is added for handling new props.
* PlotlyChart component refactored to have `componentWillUpdate` method for handling new props.
* In `/utils/datapackage.js` I've separated loading descriptor and resources for use in `index.jsx`. I kept old function though.
* Tiny change in `/utils/view.js` in `handsOnTableToHandsOnTable` method - made it to generate spec if there is no data yet.
* Small change in `MultiViews.jsx` to be able to render PlotlyChart if there is no data yet.