### PR TITLE
[s] enable handsontable column resize.

### DIFF
--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -93,6 +93,7 @@ export function handsOnTableToHandsOnTable(view) {
     , stretchH: 'all'
     , columnSorting: true
     , search: true
+    , manualColumnResize: true
   }
 }
 

--- a/tests/utils/view.js
+++ b/tests/utils/view.js
@@ -279,6 +279,7 @@ describe('Data Package View utils - HandsOnTable ', () => {
       , stretchH: 'all'
       , columnSorting: true
       , search: true
+      , manualColumnResize: true
     }
     // console.log(JSON.stringify(outSpec, null, 2));
     expect(outSpec).toEqual(expected)
@@ -307,6 +308,7 @@ describe('Data Package View utils - HandsOnTable ', () => {
       , stretchH: 'all'
       , columnSorting: true
       , search: true
+      , manualColumnResize: true
     }
     expect(outSpec).toEqual(expected)
   })


### PR DESCRIPTION
It is always better to have the option to resize the column
of a table, so that we can adjust views of the table.

This commit will enable resizing the table column.
Fix handsontable tests in test/view.js

Refs : #125