### PR TITLE
Plotly not showing in the live site

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,21 +10,16 @@
 <div class="container">
   <div class="page-header">
     <h1>
-      CO2 PPM - Trends in Atmospheric Carbon Dioxide
+      VIX - CBOE Volatility Index
     </h1>
   </div>
   <div class="react-me" data-type="data-views"></div>
   <div class="react-me" data-type="resource-preview" data-resource="0"></div>
-  <div class="react-me" data-type="resource-preview" data-resource="1"></div>
-  <div class="react-me" data-type="resource-preview" data-resource="2"></div>
-  <div class="react-me" data-type="resource-preview" data-resource="3"></div>
-  <div class="react-me" data-type="resource-preview" data-resource="4"></div>
-  <div class="react-me" data-type="resource-preview" data-resource="5"></div>
 </div>
   <script type="text/javascript">
     var bitstore = 'https://bits.staging.datapackaged.com/metadata'
     var publisherName = 'core';
-    var packageName = 'co2-ppm';
+    var packageName = 'finance-vix';
     var DATA_PACKAGE_URL= bitstore + '/' + publisherName + '/' + packageName + '/_v/latest' + '/datapackage.json';
   </script>
 </body>

--- a/src/components/dataPackageView/PlotlyChart.jsx
+++ b/src/components/dataPackageView/PlotlyChart.jsx
@@ -13,7 +13,7 @@ class PlotlyChart extends React.Component {
     Plotly.newPlot(`plotly${this.props.idx}`, this.props.data, this.props.layout)
   }
 
-  componentWillUpdate() {
+  componentDidUpdate() {
     // update the plot with new props
     Plotly.newPlot(`plotly${this.props.idx}`, this.props.data, this.props.layout)
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -47,7 +47,9 @@ async function fetchDataPackageAndDataIncrementally(dataPackageIdentifier, divEl
         exports.renderComponentInElement(divElements[0])
       } else if(view.resources) {
         view.resources.forEach(resourceIdx => {
-          if(resourceIdx === idx) {exports.renderComponentInElement(divElements[0])}
+          if(resourceIdx === idx) {
+            exports.renderComponentInElement(divElements[0])
+          }
         })
       }
     })

--- a/src/utils/view.js
+++ b/src/utils/view.js
@@ -56,6 +56,7 @@ export function simpleToPlotly(view) {
     data
     , layout: {
       title: view.resources[0].name
+      , height: 450
       , xaxis: {
         title: view.spec.group
       }

--- a/tests/components/dataPackageView/plotly.test.jsx
+++ b/tests/components/dataPackageView/plotly.test.jsx
@@ -1,6 +1,10 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import PlotlyChart from '../../../src/components/dataPackageView/PlotlyChart'
+import sinon from 'sinon'
+import Plotly from 'plotly.js/lib/core'
+
+Plotly.newPlot = jest.fn()
 
 const mockData = [{
   x: [
@@ -24,5 +28,24 @@ describe('plotly chart module', () => {
     expect(wrapper.instance().props.layout).toEqual(mockLayout)
 
     expect(wrapper.html()).toEqual(`<div id="plotly${idx}" class="PlotlyGraph"></div>`)
+  })
+})
+
+describe('how plotly mounts and updates', () => {
+  it('should call didMount and didUpdate methods after the component renders and re-renders', () => {
+    const didMount = sinon.spy(PlotlyChart.prototype, 'componentDidMount')
+    const didUpdate = sinon.spy(PlotlyChart.prototype, 'componentDidUpdate')
+    const render = sinon.spy(PlotlyChart.prototype, 'render')
+    let data, layout = undefined
+    const idx = 0
+    const wrapper = mount(<PlotlyChart data={data} layout={layout} idx={idx} />)
+    expect(didMount.calledAfter(render)).toBeTruthy()
+    expect(didMount.calledOnce).toBeTruthy()
+    expect(didUpdate.calledOnce).toBeFalsy()
+    
+    wrapper.setProps({ data: mockData, layout: mockLayout })
+    expect(didUpdate.calledAfter(render)).toBeTruthy()
+    expect(didUpdate.calledOnce).toBeTruthy()
+    expect(wrapper.props().data[0].y[0]).toEqual(14.23)
   })
 })

--- a/tests/containers/__snapshots__/MultiViews.test.jsx.snap
+++ b/tests/containers/__snapshots__/MultiViews.test.jsx.snap
@@ -29,6 +29,7 @@ exports[`MultiViews Container should render PlotlyChart component 1`] = `
     idx={0}
     layout={
       Object {
+        "height": 450,
         "title": "demo-resource",
         "xaxis": Object {
           "title": "Date",
@@ -65,6 +66,7 @@ exports[`MultiViews Container should render PlotlyChart component 1`] = `
     idx={1}
     layout={
       Object {
+        "height": 450,
         "title": "demo-resource",
         "xaxis": Object {
           "title": "Date",

--- a/tests/utils/view.js
+++ b/tests/utils/view.js
@@ -134,6 +134,7 @@ const plotlyExpected = {
     ]
     , layout: {
       title: mockDescriptor.resources[0].name
+      , height: 450
       , xaxis: {
         title: 'Date'
       }
@@ -185,6 +186,7 @@ const plotlyExpected = {
     ]
     , layout: {
       title: mockDescriptor.resources[0].name
+      , height: 450
       , xaxis: {
         title: 'Date'
       }
@@ -209,6 +211,7 @@ const plotlyExpected = {
     ]
     , layout: {
       title: mockDescriptor.resources[0].name
+      , height: 450
       , xaxis: {
         title: 'Date'
       }


### PR DESCRIPTION
* Plotly graph was not showing in the live site because we've been using `componentWillUpdate` method for re-rendering Plotly. As this method gets triggered before `render` method it was being overwritten by empty `div` element. Now it is replaced with `componentDidUpdate` that gets triggered **after** `render` method.
* Also includes tests for checking order of methods
* Explicitly added height attribute in `view.js` when generating Plotly layout spec. It is required because initially Plotly is empty and its height is very small. When data is received it does not get aligned with graph lines. Also updated tests for this method and snapshot for MultiViews.